### PR TITLE
Treat contiguous statements as belonging to the same subproblem by default (resolves #2)

### DIFF
--- a/experiments/flights/run.jl
+++ b/experiments/flights/run.jl
@@ -11,7 +11,9 @@ PClean.@model FlightsModel begin
   end
 
   @class Flight begin
-    flight_id ~ StringPrior(10, 20, flight_ids); @guaranteed flight_id
+    begin 
+      flight_id ~ StringPrior(10, 20, flight_ids); @guaranteed flight_id
+    end
     sdt ~ TimePrior(times_for_flight["$flight_id-sched_dep_time"])
     sat ~ TimePrior(times_for_flight["$flight_id-sched_arr_time"])
     adt ~ TimePrior(times_for_flight["$flight_id-act_dep_time"])
@@ -20,14 +22,18 @@ PClean.@model FlightsModel begin
 
   @class Obs begin
     @learned error_probs::Dict{String, ProbParameter{10.0, 50.0}}
-    flight ~ Flight; src ~ TrackingWebsite
-    error_prob = lowercase(src.name) == lowercase(flight.flight_id[1:2]) ? 1e-5 : error_probs[src.name]
-    sdt ~ MaybeSwap(flight.sdt, times_for_flight["$(flight.flight_id)-sched_dep_time"], error_prob)
-    sat ~ MaybeSwap(flight.sat, times_for_flight["$(flight.flight_id)-sched_arr_time"], error_prob)
-    adt ~ MaybeSwap(flight.adt, times_for_flight["$(flight.flight_id)-act_dep_time"],   error_prob)
-    aat ~ MaybeSwap(flight.aat, times_for_flight["$(flight.flight_id)-act_arr_time"],   error_prob)
+    begin 
+      flight ~ Flight; 
+      src ~ TrackingWebsite 
+    end
+    begin
+      error_prob = lowercase(src.name) == lowercase(flight.flight_id[1:2]) ? 1e-5 : error_probs[src.name]
+      sdt ~ MaybeSwap(flight.sdt, times_for_flight["$(flight.flight_id)-sched_dep_time"], error_prob)
+      sat ~ MaybeSwap(flight.sat, times_for_flight["$(flight.flight_id)-sched_arr_time"], error_prob)
+      adt ~ MaybeSwap(flight.adt, times_for_flight["$(flight.flight_id)-act_dep_time"],   error_prob)
+      aat ~ MaybeSwap(flight.aat, times_for_flight["$(flight.flight_id)-act_arr_time"],   error_prob)
+    end
   end
-
 end;
 
 query = @query FlightsModel.Obs [

--- a/experiments/rents/run.jl
+++ b/experiments/rents/run.jl
@@ -16,14 +16,12 @@ PClean.@model RentsModel begin
 
   @class Obs begin
     @learned avg_rent::Dict{String, MeanParameter{1500, 1000}}
-    begin
-      county ~ County
-      county_name ~ AddTypos(county.name, 2)
-      br ~ ChooseUniformly(room_types)
-      unit ~ ChooseUniformly(units)
-      rent_base = avg_rent["$(county.state)_$(county.countykey)_$(br)"]
-      rent ~ TransformedGaussian(rent_base, 150.0, unit)
-    end
+    county ~ County
+    county_name ~ AddTypos(county.name, 2)
+    br ~ ChooseUniformly(room_types)
+    unit ~ ChooseUniformly(units)
+    rent_base = avg_rent["$(county.state)_$(county.countykey)_$(br)"]
+    rent ~ TransformedGaussian(rent_base, 150.0, unit)
     corrected = round(unit.backward(rent))
   end;
 end;


### PR DESCRIPTION
Resolves #2 by changing the default subproblem-building strategy. 


The result is that users can be 'more unthinking' and still get good inference, but that they may need to add subproblem hints (including to latent classes) to get acceptable performance. (I had to add hints in a couple places to recover the performance from before this change.)